### PR TITLE
fix registry cache bug

### DIFF
--- a/tarsproxy/tarsregistry.go
+++ b/tarsproxy/tarsregistry.go
@@ -28,9 +28,6 @@ func GetRegistryClient(locator string) RegistryClient {
 	if mockClient != nil {
 		return mockClient
 	}
-	if impClient != nil {
-		return impClient
-	}
 	client := &Tars.Tarsregistry{}
 	if err := StringToProxy(locator, "tars.tarsregistry.Registry", client); err != nil {
 		return nil


### PR DESCRIPTION
修改tarsregistry重建时，tarscli没法感知到新的tarsregistry ip的bug