### PR TITLE
keepalive add app and server name

### DIFF
--- a/app/prestop/prestop.go
+++ b/app/prestop/prestop.go
@@ -60,7 +60,7 @@ func Prestop(waitStopTime time.Duration) error {
 	client := tarsproxy.GetRegistryClient(sConf.Locator)
 	req := &Tars.OnPrestopReq{NodeName: consts.LocalIP}
 	err = client.OnPrestop(context.Background(), req)
-	if err == nil {
+	if err != nil {
 		log.Debugf("Prestop error %v", err)
 	}
 	// notify prestop

--- a/app/supervisor/report.go
+++ b/app/supervisor/report.go
@@ -48,6 +48,9 @@ func (c *launchCmd) keepAlive(checkSucc bool) error {
 	req := Tars.KeepAliveReq{
 		NodeName: consts.LocalIP,
 		State:    state,
+		Application: sConf.Application,
+		Server: sConf.Server,
+		SetID: sConf.SetID,
 	}
 	if err := client.KeepAlive(context.Background(), &req); err != nil {
 		log.Debugf("KeepAlive error %v", err)

--- a/tarsproxy/tarsregistry.go
+++ b/tarsproxy/tarsregistry.go
@@ -28,9 +28,6 @@ func GetRegistryClient(locator string) RegistryClient {
 	if mockClient != nil {
 		return mockClient
 	}
-	if impClient != nil {
-		return impClient
-	}
 	client := &Tars.Tarsregistry{}
 	if err := StringToProxy(locator, "tars.tarsregistry.Registry", client); err != nil {
 		return nil

--- a/tarsregistry/autogen/Tars/KeepAliveReq.go
+++ b/tarsregistry/autogen/Tars/KeepAliveReq.go
@@ -12,6 +12,9 @@ import (
 type KeepAliveReq struct {
 	NodeName string `json:"nodeName"`
 	State    string `json:"state"`
+	Application string `json:"application"`
+	Server      string `json:"server"`
+	SetID       string `json:"setID"`
 }
 
 func (st *KeepAliveReq) resetDefault() {
@@ -31,6 +34,21 @@ func (st *KeepAliveReq) ReadFrom(_is *codec.Reader) error {
 	}
 
 	err = _is.Read_string(&st.State, 1, true)
+	if err != nil {
+		return err
+	}
+
+	err = _is.Read_string(&st.Application, 2, false)
+	if err != nil {
+		return err
+	}
+
+	err = _is.Read_string(&st.Server, 3, false)
+	if err != nil {
+		return err
+	}
+
+	err = _is.Read_string(&st.SetID, 4, false)
 	if err != nil {
 		return err
 	}
@@ -79,6 +97,21 @@ func (st *KeepAliveReq) WriteTo(_os *codec.Buffer) error {
 	}
 
 	err = _os.Write_string(st.State, 1)
+	if err != nil {
+		return err
+	}
+
+	err = _os.Write_string(st.Application, 2)
+	if err != nil {
+		return err
+	}
+
+	err = _os.Write_string(st.Server, 3)
+	if err != nil {
+		return err
+	}
+
+	err = _os.Write_string(st.SetID, 4)
 	if err != nil {
 		return err
 	}

--- a/tarsregistry/imp.go
+++ b/tarsregistry/imp.go
@@ -71,11 +71,14 @@ func (r *registryImp) OnStartup(ctx context.Context, Req *Tars.OnStartupReq) (er
 
 // OnPrestop is a reentrant function
 func (r *registryImp) OnPrestop(ctx context.Context, Req *Tars.OnPrestopReq) (err error) {
+	logger.Debugf("NodeName:%s", Req.NodeName)
 	return r.driver.DeleteNodeConf(ctx, Req.NodeName)
 }
 
 // KeepAlive is a reentrant function
 func (r *registryImp) KeepAlive(ctx context.Context, Req *Tars.KeepAliveReq) (err error) {
+	logger.Debugf("NodeName:%s, State:%s, Application:%s, Server:%s, SetID:%s", 
+		Req.NodeName, Req.State, Req.Application, Req.Server, Req.SetID)
 	if err := r.driver.KeepAliveNode(ctx, Req.NodeName); err != nil {
 		logger.Errorf("KeepAliveNode error %v", err)
 		return err
@@ -83,5 +86,5 @@ func (r *registryImp) KeepAlive(ctx context.Context, Req *Tars.KeepAliveReq) (er
 	if Req.State == "" {
 		Req.State = "active"
 	}
-	return r.driver.SetServerState(ctx, Req.NodeName, Req.State)
+	return r.driver.SetServerState(ctx, Req.NodeName, Req.Application, Req.Server, Req.State)
 }

--- a/tarsregistry/keepalive.go
+++ b/tarsregistry/keepalive.go
@@ -13,6 +13,9 @@ func (s *registryImp) keepAlive(startReq *Tars.OnStartupReq) {
 	keepReq := &Tars.KeepAliveReq{
 		NodeName: startReq.NodeName,
 		State:    "active",
+		Application: startReq.Application,
+		Server: startReq.Server,
+		SetID: startReq.SetID,
 	}
 	for range time.NewTicker(time.Second * 10).C {
 		if !hasReg {

--- a/tarsregistry/protocol/tarsregistry.tars
+++ b/tarsregistry/protocol/tarsregistry.tars
@@ -27,6 +27,9 @@ module tars
     struct keepAliveReq{
         0 require string nodeName;
         1 require string state; // inactive or active
+        2 optional string application;
+        3 optional string server;
+        4 optional string setID;
     };
 
     interface tarsregistry

--- a/tarsregistry/store/mysql.go
+++ b/tarsregistry/store/mysql.go
@@ -103,10 +103,18 @@ func (m *mysqlDriver) KeepAliveNode(ctx context.Context, nodeName string) error 
 	return err
 }
 
-func (m *mysqlDriver) SetServerState(ctx context.Context, nodeName, state string) error {
-	sql := "update t_server_conf set present_state = ? where node_name = ?"
+func (m *mysqlDriver) SetServerState(ctx context.Context, nodeName, application, server, state string) error {
+	sql := "update t_node_info set present_state = ? where node_name = ?"
 	_, err := m.db.ExecContext(ctx, sql, state, nodeName)
-	sql = "update t_node_info set present_state = ? where node_name = ?"
-	_, err = m.db.ExecContext(ctx, sql, state, nodeName)
+
+	// compatible with old report
+	if application == "" || server == "" {
+		sql = "update t_server_conf set present_state = ? where node_name = ?"
+		_, err = m.db.ExecContext(ctx, sql, state, nodeName)
+
+	} else {
+		sql = "update t_server_conf set present_state = ? where node_name = ? and application = ? and server_name = ?"
+		_, err = m.db.ExecContext(ctx, sql, state, nodeName, application, server)
+	}
 	return err
 }

--- a/tarsregistry/store/store.go
+++ b/tarsregistry/store/store.go
@@ -35,5 +35,5 @@ type Store interface {
 	RegistryAdapter(ctx context.Context, conf []*AdapterConf) error
 	DeleteNodeConf(ctx context.Context, nodeName string) error
 	KeepAliveNode(ctx context.Context, nodeName string) error
-	SetServerState(ctx context.Context, nodeName, state string) error
+	SetServerState(ctx context.Context, nodeName, application, server, state string) error
 }


### PR DESCRIPTION
目前在异常情况下可能导致pod下线后db中数据还存在。
一段时间后异常节点会变为inactive状态。
但是在ip被复用后，会把inactive节点重新变为active，导致registry上会存在一个不可访问节点，客户端访问出错。
目前的改动方案可以解决大部分问题，但是如果异常发生->异常节点变为inactive这段时间内ip就被复用了，还是会存在上面的问题。后面可以考虑心跳机制从node改成node+server