### PR TITLE
fix pod restart bug

### DIFF
--- a/app/prestop/prestop.go
+++ b/app/prestop/prestop.go
@@ -58,6 +58,10 @@ func Prestop(waitStopTime time.Duration) error {
 
 	// invoke tars registry
 	client := tarsproxy.GetRegistryClient(sConf.Locator)
+	if client == nil {
+		log.Debugf("GetRegistryClient return nil, Locator %s", sConf.Locator)
+		return nil
+	}
 	req := &Tars.OnPrestopReq{NodeName: consts.LocalIP}
 	err = client.OnPrestop(context.Background(), req)
 	if err != nil {

--- a/app/supervisor/report.go
+++ b/app/supervisor/report.go
@@ -43,8 +43,16 @@ func (c *launchCmd) keepAlive(checkSucc bool) error {
 		}
 	}
 
+	if err := ioutil.WriteFile(stateFile, []byte(state), 0644); err != nil {
+		log.Debugf("WriteFile error %v", err)
+	}
+
 	// invoke tars registry and set server status
 	client := tarsproxy.GetRegistryClient(sConf.Locator)
+	if client == nil {
+		log.Debugf("GetRegistryClient return nil, Locator %s", sConf.Locator)
+		return nil
+	}
 	req := Tars.KeepAliveReq{
 		NodeName: consts.LocalIP,
 		State:    state,
@@ -55,9 +63,6 @@ func (c *launchCmd) keepAlive(checkSucc bool) error {
 	if err := client.KeepAlive(context.Background(), &req); err != nil {
 		log.Debugf("KeepAlive error %v", err)
 		return nil
-	}
-	if err := ioutil.WriteFile(stateFile, []byte(state), 0644); err != nil {
-		log.Debugf("WriteFile error %v", err)
 	}
 	return nil
 }


### PR DESCRIPTION
keepAlive之前是先去registry上报心跳，再更新check_status文件。这样如果registry不通的话，check_status文件就一直不会有更新。过一段时间后（默认1分钟）hzcheck开始失败，从而导致pod重启