### PR TITLE
Add terminationGracePeriodSeconds for registry.yaml

### DIFF
--- a/baseserver/yaml/registry.yaml
+++ b/baseserver/yaml/registry.yaml
@@ -24,6 +24,7 @@ spec:
       labels:
         app: tars-registry
     spec:
+      terminationGracePeriodSeconds: 90    
       containers:
       - name: tars-cppregistry
         image: ccr.ccs.tencentyun.com/tarsbase/cppregistry:v1.1.3


### PR DESCRIPTION
添加 terminationGracePeriodSeconds: 90 配置，确保tars-registry本身也能优雅退出。